### PR TITLE
Make distributions for priors separate classes from the prior evaluator

### DIFF
--- a/pycbc/inference/__init__.py
+++ b/pycbc/inference/__init__.py
@@ -1,1 +1,2 @@
 from pycbc.inference.likelihood import *
+from pycbc.inference.prior import *

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -116,7 +116,7 @@ class _BaseLikelihoodEvaluator:
             for det,d in self._data.items()])
         # store prior
         if prior is None:
-            self._prior = pyprior.no_prior
+            self._prior = pyprior.flat_prior
         else:
             self._prior = prior
 

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -31,6 +31,12 @@ from pycbc.types import Array
 import prior as pyprior
 import numpy
 
+def _noprior(*params):
+    """Dummy function to just return 0 if no prior is provided in a
+    likelihood generator.
+    """
+    return 0.
+
 class _BaseLikelihoodEvaluator:
     """Base container class for generating waveforms, storing the data, and
     computing log likelihoods. The likelihood function defined here does
@@ -116,7 +122,7 @@ class _BaseLikelihoodEvaluator:
             for det,d in self._data.items()])
         # store prior
         if prior is None:
-            self._prior = pyprior.flat_prior
+            self._prior = _noprior 
         else:
             self._prior = prior
 
@@ -204,7 +210,7 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
             parameter space.
         """
         # get prior
-        prior = self._prior(params)
+        prior = self._prior(*params)
         # prior will return -numpy.inf if params are invalid
         if prior == -numpy.inf:
             return -numpy.inf

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -124,6 +124,11 @@ class _BaseLikelihoodEvaluator:
         if prior is None:
             self._prior = _noprior 
         else:
+            # check that the variable args of the prior evaluator is the same
+            # as the waveform generator
+            if prior.variable_args != self._waveform_generator.variable_args:
+                raise ValueError("variable args of prior and waveform "
+                    "generator do not match")
             self._prior = prior
 
     @property

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -115,10 +115,10 @@ class _BaseLikelihoodEvaluator:
             d[kmin:kmax].inner(d[kmin:kmax]*self._weight[det][kmin:kmax]).real/2.)
             for det,d in self._data.items()])
         # store prior
-        if prior:
-            self._prior = prior
-        else:
+        if prior is None:
             self._prior = pyprior.no_prior
+        else:
+            self._prior = prior
 
     @property
     def waveform_generator(self):
@@ -204,7 +204,7 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
             parameter space.
         """
         # get prior
-        prior = self.prior(params)
+        prior = self._prior(params)
         # prior will return -numpy.inf if params are invalid
         if prior == -numpy.inf:
             return -numpy.inf

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -198,6 +198,14 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
     >>> ax.plot(times, lls)
     [<matplotlib.lines.Line2D at 0x12780ff90>]
     >>> fig.show()
+
+    Create a prior and use it (see prior module for more details):
+    >>> from pycbc.inference import prior
+    >>> uniform_prior = prior.Uniform(tc=(tsig-0.2,tsig+0.2))
+    >>> prior_eval = prior.PriorEvaluator(['tc'], uniform_prior)
+    >>> likelihood_eval = inference.GaussianLikelihood(generator, signal, 20., psds=psds, prior=prior_eval)
+    >>> likelihood_eval.loglikelihood([tsig])
+    0.91629073187415422
     """
 
     def loglikelihood(self, params):

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -28,15 +28,149 @@ for parameter estimation.
 
 import numpy
 
-def flat_prior(param):
-    """ Simple flat prior for a single parameter.
+#
+#   Distributions for priors
+#
+class Uniform(object):
     """
-    return 0.0
+    A uniform distribution on the given parameters. The parameters are
+    independent of each other. Instances of this class can be called like
+    a function. By default, logpdf will be called, but this can be changed
+    by setting the class's __call__ method to its pdf method.
 
-# different prior single parameters can have
-prior_distributions = {
-    "flat" : flat_prior,
-}
+    Parameters
+    ----------
+    \**params :
+        The keyword arguments should provide the names of parameters and their
+        corresponding bounds, as tuples.
+
+    Class Attributes
+    ----------------
+    name : 'uniform'
+        The name of this distribution.
+
+    Attributes
+    ----------
+    params : list of strings
+        The list of parameter names.
+    bounds : dict
+        A dictionary of the parameter names and their bounds.
+    norm : float
+        The normalization of the multi-dimensional pdf.
+    lognorm : float
+        The log of the normalization.
+
+    Example
+    -------
+    Create a 2 dimensional uniform distribution:
+    >>> dist = prior.Uniform(mass1=(10.,50.), mass2=(10.,50.))
+
+    Get the log of the pdf at a particular value:
+    >>> dist.logpdf(mass1=25., mass2=10.)
+    -7.3777589082278725
+
+    Do the same by calling the distribution:
+    >>> dist(mass1=25., mass2=10.)
+    -7.3777589082278725
+
+    Generate some random values:
+    >>> dist.rvs(size=3)
+    array([(36.90885758394699, 51.294212757995254),
+           (39.109058546060346, 13.36220145743631),
+           (34.49594465315212, 47.531953033719454)], 
+          dtype=[('mass1', '<f8'), ('mass2', '<f8')])
+    """
+    name = 'uniform'
+    def __init__(self, **params):
+        self._bounds = params
+        self._params = sorted(params.keys())
+        # temporarily suppress numpy divide by 0 warning
+        numpy.seterr(divide='ignore')
+        self._lognorm = -sum([numpy.log(abs(bnd[1]-bnd[0]))
+                                    for bnd in self._bounds.values()])
+        self._norm = numpy.exp(self._lognorm)
+        numpy.seterr(divide='warn')
+
+    @property
+    def params(self):
+        return self._params
+
+    @property
+    def bounds(self):
+        return self._bounds
+
+    @property
+    def norm(self):
+        return self._norm
+
+    @property
+    def lognorm(self):
+        return self._lognorm
+
+    def __contains__(self, params):
+        try:
+            return all([(params[p] >= self._bounds[p][0]) &
+                        (params[p] < self._bounds[p][1])
+                       for p in self._params])
+        except KeyError:
+            raise ValueError("must provide all parameters [%s]" %(
+                ', '.join(self._params)))
+
+    def pdf(self, **kwargs):
+        """
+        Returns the pdf at the given values. The keyword arguments must contain
+        all of parameters in self's params. Unrecognized arguments are ignored.
+        """
+        if kwargs in self:
+            return self._norm
+        else:
+            return 0.
+
+    def logpdf(self, **kwargs):
+        """
+        Returns the log of the pdf at the given values. The keyword arguments
+        must contain all of parameters in self's params. Unrecognized arguments
+        are ignored.
+        """
+        if kwargs in self:
+            return self._lognorm
+        else:
+            return -numpy.inf
+
+    __call__ = logpdf
+
+    def rvs(self, size=1, param=None):
+        """Gives a set of random values drawn from this distribution.
+
+        Parameters
+        ----------
+        size : {1, int}
+            The number of values to generate; default is 1.
+        param : {None, string}
+            If provided, will just return values for the given parameter.
+            Otherwise, returns random values for each parameter.
+
+        Returns
+        -------
+        structured array
+            The random values in a numpy structured array. If a param was
+            specified, the array will only have an element corresponding to the
+            given parameter. Otherwise, the array will have an element for each
+            parameter in self's params.
+        """
+        if param is not None:
+            dtype = [(param, float)]
+        else:
+            dtype = [(p, float) for p in self.params]
+        arr = numpy.zeros(size, dtype=dtype)
+        for (p,_) in dtype:
+            arr[p] = numpy.random.uniform(self._bounds[p][0],
+                                        self._bounds[p][1],
+                                        size=size)
+        return arr
+
+priors = {Uniform.name: Uniform}
+
 
 class PriorEvaluator(object):
     """
@@ -45,46 +179,47 @@ class PriorEvaluator(object):
     Parameters
     ----------
     variable_args : list
-        A list of str that contain the names of the variable parameters.
-    params_dist : {'flat'}
-        A list of str that contain the names of the function in the prior
-        module to use to calculate the prior for that variable.
-    params_min : {None, list}
-        The lowest acceptable value for parameter.
-    params_max : {None, list}
-        The largest acceptable value for parameter.
+        A list of strings that contain the names of the variable parameters and
+        the order they are expected when the class is called.
+    \*distributions :
+        The rest of the arguments must be instances of distributions describing
+        the priors on the variable parameters. A single distribution may contain
+        multiple parameters. The set of all params across the distributions
+        (retrieved from the distributions' params attribute) must be the same
+        as the set of variable_args provided.
+
+    Attributes
+    ----------
+    variable_args : tuple
+        The parameters expected when the evaluator is called.
+    distributions : list
+        The distributions for the parameters.
     """
 
-    def __init__(self, variable_args, params_dist, params_min=None,
-                 params_max=None):
+    def __init__(self, variable_args, *distributions):
 
         # store the names of the variable params
-        self.variable_args = variable_args
+        self.variable_args = tuple(variable_args)
+        # store the distributions
+        self.distributions = distributions
 
-        # store the distribution for the variable params
-        self.params_dist = params_dist
+        # check that all of the variable args are described by the given
+        # distributions
+        distparams = set()
+        [distparams.update(set(dist.params)) for dist in distributions]
+        varset = set(self.variable_args)
+        missing_params = distparams - varset
+        if missing_params:
+            raise ValueError("provided variable_args do not include "
+                "parameters %s" %(','.join(missing_params)) + " which are "
+                "required by the provided distributions")
+        extra_params = varset - distparams
+        if extra_params:
+            raise ValueError("variable_args %s " %(','.join(extra_params)) +
+                "are not in any of the provided distributions")
 
-        # store the minimum and maximum acceptable values for a variable param
-        # if nothing is specified then use -inf to inf
-        if params_min is None:
-            self.params_min = numpy.ones(len(self.variable_args)) * -numpy.inf
-        else:
-            self.params_min = numpy.array(params_min)
-        if params_max is None:
-            self.params_max = numpy.ones(len(self.variable_args)) * numpy.inf
-        else:
-            self.params_max = numpy.array(params_max)
-
-    def __call__(self, params):
+    def __call__(self, *params):
         """ Evalualate prior for parameters.
         """
-
-        # check if values are valid and if params are outside of min and max
-        # acceptable values then return -inf
-        params = numpy.array(params)
-        if ((params < self.params_min) | (params > self.params_max)).any():
-            return -numpy.inf
-
-        # evaluate prior for each parameter
-        return sum([prior_distributions[self.params_dist[i]](param) for i,param in enumerate(params)])
-
+        params = dict(zip(self.variable_args, params))
+        return sum([d(**params) for d in self.distributions])

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -33,6 +33,16 @@ def no_prior(params):
     """
     return 0.0
 
+def flat_prior(param):
+    """ Simple flat prior for a single parameter.
+    """
+    return 0.0
+
+# different prior single parameters can have
+prior_distributions = {
+    "flat" : flat_prior,
+}
+
 class PriorEvaluator(object):
     """
     Callable class that calculates the prior.
@@ -70,11 +80,6 @@ class PriorEvaluator(object):
         else:
             self.params_max = numpy.array(params_max)
 
-    def flat(self, param):
-        """ Simple flat prior for a single parameter.
-        """
-        return 0.0
-
     def __call__(self, params):
         """ Evalualate prior for parameters.
         """
@@ -87,7 +92,5 @@ class PriorEvaluator(object):
             return -numpy.inf
 
         # evaluate prior for each parameter
-        val = sum([getattr(self, self.params_dist[i])(param) for i,param in enumerate(params)])
-
-        return val
+        return sum([prior_distributions[self.params_dist[i]](param) for i,param in enumerate(params)])
 

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -82,7 +82,7 @@ class PriorEvaluator(object):
         # check if values are valid and if params are outside of min and max
         # acceptable values then return -inf
         params = numpy.array(params)
-        if ((params < self.params_min) | (params > self.params_max)).all():
+        if ((params < self.params_min) | (params > self.params_max)).any():
             return -numpy.inf
 
         # evaluate prior for each parameter

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -57,7 +57,7 @@ class PriorEvaluator(object):
         self.variable_params = variable_params
 
         # store the distribution for the variable params
-        self.params_dist = [getattr(PriorEvaluator, dist) for dist in params_dist]
+        self.params_dist = params_dist
 
         # store the minimum and maximum acceptable values for a variable param
         # if nothing is specified then use -inf to inf
@@ -87,7 +87,7 @@ class PriorEvaluator(object):
             return -numpy.inf
 
         # evaluate prior for each parameter
-        val = sum([self.params_dist[i](self, param) for i,param in enumerate(params)])
+        val = sum([getattr(self, self.params_dist[i])(param) for i,param in enumerate(params)])
 
         return val
 

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -87,8 +87,7 @@ class PriorEvaluator(object):
         # check if values are valid and if params are outside of min and max
         # acceptable values then return -inf
         params = numpy.array(params)
-        result = sum((params < self.params_min) | (params > self.params_max))
-        if result:
+        if ((params < self.params_min) | (params > self.params_max)).all():
             return -numpy.inf
 
         # evaluate prior for each parameter

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -39,22 +39,22 @@ class PriorEvaluator(object):
 
     Parameters
     ----------
-    variable_names : list
+    variable_args : list
         A list of str that contain the names of the variable parameters.
     params_dist : {'flat'}
-        A list of str that contain the names of the PriorEvaluator class
-        function to use to calculate the prior for that variable.
+        A list of str that contain the names of the function in the prior
+        module to use to calculate the prior for that variable.
     params_min : {None, list}
         The lowest acceptable value for parameter.
     params_max : {None, list}
         The largest acceptable value for parameter.
     """
 
-    def __init__(self, variable_params, params_dist, params_min=None,
+    def __init__(self, variable_args, params_dist, params_min=None,
                  params_max=None):
 
         # store the names of the variable params
-        self.variable_params = variable_params
+        self.variable_args = variable_args
 
         # store the distribution for the variable params
         self.params_dist = params_dist
@@ -62,11 +62,11 @@ class PriorEvaluator(object):
         # store the minimum and maximum acceptable values for a variable param
         # if nothing is specified then use -inf to inf
         if params_min is None:
-            self.params_min = numpy.ones(len(self.variable_params)) * -numpy.inf
+            self.params_min = numpy.ones(len(self.variable_args)) * -numpy.inf
         else:
             self.params_min = numpy.array(params_min)
         if params_max is None:
-            self.params_max = numpy.ones(len(self.variable_params)) * numpy.inf
+            self.params_max = numpy.ones(len(self.variable_args)) * numpy.inf
         else:
             self.params_max = numpy.array(params_max)
 

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -26,10 +26,68 @@ This modules provides classes and functions for evaluating the prior
 for parameter estimation.
 """
 
+import numpy
+
 def no_prior(params):
     """ Function that returns default value if user does not specify a prior.
     """
     return 0
 
+class PriorEvaluator(object):
+    """
+    Callable class that calculates the prior.
 
+    Parameters
+    ----------
+    variable_names : list
+        A list of str that contain the names of the variable parameters.
+    params_dist : {'flat'}
+        A list of str that contain the names of the PriorEvaluator class
+        function to use to calculate the prior for that variable.
+    params_min : {None, list}
+        The lowest acceptable value for parameter.
+    params_max : {None, list}
+        The largest acceptable value for parameter.
+    """
+
+    def __init__(self, variable_params, params_dist, params_min=None,
+                 params_max=None):
+
+        # store the names of the variable params
+        self.variable_params = variable_params
+
+        # store the distribution for the variable params
+        self.params_dist = [getattr(PriorEvaluator, dist) for dist in params_dist]
+
+        # store the minimum and maximum acceptable values for a variable param
+        # if nothing is specified then use -inf to inf
+        if params_min is None:
+            self.params_min = numpy.ones(len(self.variable_params)) * -numpy.inf
+        else:
+            self.params_min = numpy.array(params_min)
+        if params_max is None:
+            self.params_max = numpy.ones(len(self.variable_params)) * numpy.inf
+        else:
+            self.params_max = numpy.array(params_max)
+
+    def flat(self, param):
+        """ Simple flat prior for a single parameter.
+        """
+        return 0.0
+
+    def __call__(self, params):
+        """ Evalualate prior for parameters.
+        """
+
+        # check if values are valid and if params are outside of min and max
+        # acceptable values then return -inf
+        params = numpy.array(params)
+        result = sum((params < self.params_min) | (params > self.params_max))
+        if result:
+            return -numpy.inf
+
+        # evaluate prior for each parameter
+        val = sum([self.params_dist[i](self, param) for i,param in enumerate(params)])
+
+        return val
 

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -31,7 +31,7 @@ import numpy
 def no_prior(params):
     """ Function that returns default value if user does not specify a prior.
     """
-    return 0
+    return 0.0
 
 class PriorEvaluator(object):
     """

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -28,11 +28,6 @@ for parameter estimation.
 
 import numpy
 
-def no_prior(params):
-    """ Function that returns default value if user does not specify a prior.
-    """
-    return 0.0
-
 def flat_prior(param):
     """ Simple flat prior for a single parameter.
     """

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2016  Christopher M. Biwer
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+"""
+This modules provides classes and functions for evaluating the prior
+for parameter estimation.
+"""
+
+def no_prior(params):
+    """ Function that returns default value if user does not specify a prior.
+    """
+    return 0
+
+
+

--- a/pycbc/inference/sampler.py
+++ b/pycbc/inference/sampler.py
@@ -1,0 +1,135 @@
+# Copyright (C) 2016  Christopher M. Biwer
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+#
+# =============================================================================
+#
+#                                   Preamble
+#
+# =============================================================================
+#
+"""
+This modules provides classes and functions for using different sampler
+packages for parameter estimation.
+"""
+
+import kombine
+
+class _BaseSampler(object):
+    """ Base container class for running the MCMC sampler.
+
+    Parameters
+    ----------
+    sampler : sampler class
+        An instance of the sampler class from its package.
+    """
+
+    def __init__(self, sampler):
+        self.sampler = sampler
+
+    @property
+    def acceptance_fraction(self):
+        """ This function should return the fraction of walkers that accepted
+        each step as an array.
+        """
+        return ValueError("acceptance_fraction function not set.")
+
+    @property
+    def chain(self):
+        """ This function should return the past samples as a
+        initerations x nwalker x ndim array.
+        """
+        return ValueError("chain function not set.")
+
+    def burn_in(self, initial_values):
+        """ This function should burn in the MCMC.
+        """
+        raise ValueError("burn_in function not set.")
+
+    def run_mcmc(self, niterations):
+        """ This function should run the MCMC for the number of samples.
+        """
+        raise ValueError("run_mcmc function not set.")
+
+class KombineSampler(_BaseSampler):
+    """ This class is used to construct the sampler from the kombine package.
+
+    Parameters
+    ----------
+    likelihood_evaluator : likelihood class
+        An instance of the likelihood class from the
+        pycbc.inference.likelihood module.
+    nwalkers : int
+        Number of walkers to use in MCMC.
+    ndim : int
+        Number of dimensions in the parameter space. If transd is True this is
+        the number of unique dimensions across the parameter spaces.
+    transd : bool
+        If True, the sampler will operate across parameter spaces using a
+        kombine.clustered_kde.TransdimensionalKDE proposal distribution. In
+        this mode a masked array with samples in each of the possible sets of
+        dimensions must be given for the initial ensemble distribution.
+    nprocesses : {None, int}
+        Number of processes to use with multiprocessing. If None, all available
+        cores are used.
+    """
+
+    def __init__(self, likelihood_evaluator, nwalkers=0, ndim=0,
+                        transd=False, nprocess=None):
+
+        # construct sampler 
+        sampler = kombine.Sampler(nwalkers, ndim, self.likelihood_evaluator,
+                                          transd=transd, processes=nprocesses)
+        super(KombineSampler, self).__init__(self, sampler)
+
+    @property
+    def acceptance_fraction(self):
+        """ Get the fraction of walkers that accepted each step as an arary.
+        """
+        return self.sampler.acceptance_fraction
+
+    @property
+    def chain(self):
+        """ Get all past samples as an niterations x nwalker x ndim array.
+        """
+        return self.sampler.chain
+
+    def burn_in(self, initial_values):
+        """ Evolve an ensemble until the acceptance rate becomes roughly
+        constant. This is done by splitting acceptances in half and checking
+        for statistical consistency. This isn’t guaranteed to return a fully
+        burned-in ensemble, but usually does.
+
+        Parameters
+        ----------
+        initial_values : numpy.array
+            An nwalkers x ndim array of initial values for walkers.
+        """
+        self.sampler.burn_in(initial_values)
+
+    def run_mcmc(self, niterations):
+        """ Advance the MCMC for a number of samples.
+
+        Parameters
+        ----------
+        niterations : int
+            Number of samples to get from MCMC.
+        """
+        self.sampler.run_mcmc(niterations)
+
+samplers = {
+    "kombine" : KombineSampler,
+}

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -80,7 +80,7 @@ class BaseGenerator(object):
     """
     def __init__(self, generator, variable_args=(), **frozen_params):
         self.generator = generator
-        self.variable_args = variable_args
+        self.variable_args = tuple(variable_args)
         self.frozen_params = frozen_params
         # we'll keep a dictionary of the current parameters for fast
         # generation
@@ -197,7 +197,7 @@ class FDomainDetFrameGenerator(object):
         location params are passed to this class's generate function.
     frozen_location_args : dict
         Any location parameters that were included in the frozen_params.
-    variable_args : list
+    variable_args : tuple
         The list of names of arguments that are passed to the generate
         function.
 

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ install_requires =  setup_requires + ['Mako>=1.0.1',
                       'pyRXP>=2.1.0',
                       'pycbc-pylal>=0.9.5',
                       'pycbc-glue>=0.9.8',
+                      'kombine',
                       ]
 links = ['https://github.com/ligo-cbc/mpld3/tarball/master#egg=mpld3-0.3git']
 


### PR DESCRIPTION
This introduces a class for producing uniform priors between some boundaries, and removes boundaries from the PriorEvaluator class. This makes PriorEvaluator agnostic to the details of a particular distribution. For example, in the future we'll probably have priors that have no boundaries (say, for a cyclic function, or for a Gaussian distribution). These can be added as new classes to the module. This patch also moves the no prior (last called flat_prior) function to likelihood.py; it's not really a prior, just a crutch for the likelihood generator. Also add some documentation and sanity checking when the likelihood evaluator is initialized with a prior.
