### PR TITLE
Make distributions for priors separate classes from the prior evaluator

### DIFF
--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -31,6 +31,12 @@ from pycbc.types import Array
 import prior as pyprior
 import numpy
 
+def _noprior(*params):
+    """Dummy function to just return 0 if no prior is provided in a
+    likelihood generator.
+    """
+    return 0.
+
 class _BaseLikelihoodEvaluator:
     """Base container class for generating waveforms, storing the data, and
     computing log likelihoods. The likelihood function defined here does
@@ -116,7 +122,7 @@ class _BaseLikelihoodEvaluator:
             for det,d in self._data.items()])
         # store prior
         if prior is None:
-            self._prior = pyprior.flat_prior
+            self._prior = _noprior 
         else:
             self._prior = prior
 
@@ -204,7 +210,7 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
             parameter space.
         """
         # get prior
-        prior = self._prior(params)
+        prior = self._prior(*params)
         # prior will return -numpy.inf if params are invalid
         if prior == -numpy.inf:
             return -numpy.inf

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -124,6 +124,11 @@ class _BaseLikelihoodEvaluator:
         if prior is None:
             self._prior = _noprior 
         else:
+            # check that the variable args of the prior evaluator is the same
+            # as the waveform generator
+            if prior.variable_args != self._waveform_generator.variable_args:
+                raise ValueError("variable args of prior and waveform "
+                    "generator do not match")
             self._prior = prior
 
     @property

--- a/pycbc/inference/likelihood.py
+++ b/pycbc/inference/likelihood.py
@@ -198,6 +198,14 @@ class GaussianLikelihood(_BaseLikelihoodEvaluator):
     >>> ax.plot(times, lls)
     [<matplotlib.lines.Line2D at 0x12780ff90>]
     >>> fig.show()
+
+    Create a prior and use it (see prior module for more details):
+    >>> from pycbc.inference import prior
+    >>> uniform_prior = prior.Uniform(tc=(tsig-0.2,tsig+0.2))
+    >>> prior_eval = prior.PriorEvaluator(['tc'], uniform_prior)
+    >>> likelihood_eval = inference.GaussianLikelihood(generator, signal, 20., psds=psds, prior=prior_eval)
+    >>> likelihood_eval.loglikelihood([tsig])
+    0.91629073187415422
     """
 
     def loglikelihood(self, params):

--- a/pycbc/inference/prior.py
+++ b/pycbc/inference/prior.py
@@ -28,15 +28,149 @@ for parameter estimation.
 
 import numpy
 
-def flat_prior(param):
-    """ Simple flat prior for a single parameter.
+#
+#   Distributions for priors
+#
+class Uniform(object):
     """
-    return 0.0
+    A uniform distribution on the given parameters. The parameters are
+    independent of each other. Instances of this class can be called like
+    a function. By default, logpdf will be called, but this can be changed
+    by setting the class's __call__ method to its pdf method.
 
-# different prior single parameters can have
-prior_distributions = {
-    "flat" : flat_prior,
-}
+    Parameters
+    ----------
+    \**params :
+        The keyword arguments should provide the names of parameters and their
+        corresponding bounds, as tuples.
+
+    Class Attributes
+    ----------------
+    name : 'uniform'
+        The name of this distribution.
+
+    Attributes
+    ----------
+    params : list of strings
+        The list of parameter names.
+    bounds : dict
+        A dictionary of the parameter names and their bounds.
+    norm : float
+        The normalization of the multi-dimensional pdf.
+    lognorm : float
+        The log of the normalization.
+
+    Example
+    -------
+    Create a 2 dimensional uniform distribution:
+    >>> dist = prior.Uniform(mass1=(10.,50.), mass2=(10.,50.))
+
+    Get the log of the pdf at a particular value:
+    >>> dist.logpdf(mass1=25., mass2=10.)
+    -7.3777589082278725
+
+    Do the same by calling the distribution:
+    >>> dist(mass1=25., mass2=10.)
+    -7.3777589082278725
+
+    Generate some random values:
+    >>> dist.rvs(size=3)
+    array([(36.90885758394699, 51.294212757995254),
+           (39.109058546060346, 13.36220145743631),
+           (34.49594465315212, 47.531953033719454)], 
+          dtype=[('mass1', '<f8'), ('mass2', '<f8')])
+    """
+    name = 'uniform'
+    def __init__(self, **params):
+        self._bounds = params
+        self._params = sorted(params.keys())
+        # temporarily suppress numpy divide by 0 warning
+        numpy.seterr(divide='ignore')
+        self._lognorm = -sum([numpy.log(abs(bnd[1]-bnd[0]))
+                                    for bnd in self._bounds.values()])
+        self._norm = numpy.exp(self._lognorm)
+        numpy.seterr(divide='warn')
+
+    @property
+    def params(self):
+        return self._params
+
+    @property
+    def bounds(self):
+        return self._bounds
+
+    @property
+    def norm(self):
+        return self._norm
+
+    @property
+    def lognorm(self):
+        return self._lognorm
+
+    def __contains__(self, params):
+        try:
+            return all([(params[p] >= self._bounds[p][0]) &
+                        (params[p] < self._bounds[p][1])
+                       for p in self._params])
+        except KeyError:
+            raise ValueError("must provide all parameters [%s]" %(
+                ', '.join(self._params)))
+
+    def pdf(self, **kwargs):
+        """
+        Returns the pdf at the given values. The keyword arguments must contain
+        all of parameters in self's params. Unrecognized arguments are ignored.
+        """
+        if kwargs in self:
+            return self._norm
+        else:
+            return 0.
+
+    def logpdf(self, **kwargs):
+        """
+        Returns the log of the pdf at the given values. The keyword arguments
+        must contain all of parameters in self's params. Unrecognized arguments
+        are ignored.
+        """
+        if kwargs in self:
+            return self._lognorm
+        else:
+            return -numpy.inf
+
+    __call__ = logpdf
+
+    def rvs(self, size=1, param=None):
+        """Gives a set of random values drawn from this distribution.
+
+        Parameters
+        ----------
+        size : {1, int}
+            The number of values to generate; default is 1.
+        param : {None, string}
+            If provided, will just return values for the given parameter.
+            Otherwise, returns random values for each parameter.
+
+        Returns
+        -------
+        structured array
+            The random values in a numpy structured array. If a param was
+            specified, the array will only have an element corresponding to the
+            given parameter. Otherwise, the array will have an element for each
+            parameter in self's params.
+        """
+        if param is not None:
+            dtype = [(param, float)]
+        else:
+            dtype = [(p, float) for p in self.params]
+        arr = numpy.zeros(size, dtype=dtype)
+        for (p,_) in dtype:
+            arr[p] = numpy.random.uniform(self._bounds[p][0],
+                                        self._bounds[p][1],
+                                        size=size)
+        return arr
+
+priors = {Uniform.name: Uniform}
+
 
 class PriorEvaluator(object):
     """
@@ -45,46 +179,47 @@ class PriorEvaluator(object):
     Parameters
     ----------
     variable_args : list
-        A list of str that contain the names of the variable parameters.
-    params_dist : {'flat'}
-        A list of str that contain the names of the function in the prior
-        module to use to calculate the prior for that variable.
-    params_min : {None, list}
-        The lowest acceptable value for parameter.
-    params_max : {None, list}
-        The largest acceptable value for parameter.
+        A list of strings that contain the names of the variable parameters and
+        the order they are expected when the class is called.
+    \*distributions :
+        The rest of the arguments must be instances of distributions describing
+        the priors on the variable parameters. A single distribution may contain
+        multiple parameters. The set of all params across the distributions
+        (retrieved from the distributions' params attribute) must be the same
+        as the set of variable_args provided.
+
+    Attributes
+    ----------
+    variable_args : tuple
+        The parameters expected when the evaluator is called.
+    distributions : list
+        The distributions for the parameters.
     """
 
-    def __init__(self, variable_args, params_dist, params_min=None,
-                 params_max=None):
+    def __init__(self, variable_args, *distributions):
 
         # store the names of the variable params
-        self.variable_args = variable_args
+        self.variable_args = tuple(variable_args)
+        # store the distributions
+        self.distributions = distributions
 
-        # store the distribution for the variable params
-        self.params_dist = params_dist
+        # check that all of the variable args are described by the given
+        # distributions
+        distparams = set()
+        [distparams.update(set(dist.params)) for dist in distributions]
+        varset = set(self.variable_args)
+        missing_params = distparams - varset
+        if missing_params:
+            raise ValueError("provided variable_args do not include "
+                "parameters %s" %(','.join(missing_params)) + " which are "
+                "required by the provided distributions")
+        extra_params = varset - distparams
+        if extra_params:
+            raise ValueError("variable_args %s " %(','.join(extra_params)) +
+                "are not in any of the provided distributions")
 
-        # store the minimum and maximum acceptable values for a variable param
-        # if nothing is specified then use -inf to inf
-        if params_min is None:
-            self.params_min = numpy.ones(len(self.variable_args)) * -numpy.inf
-        else:
-            self.params_min = numpy.array(params_min)
-        if params_max is None:
-            self.params_max = numpy.ones(len(self.variable_args)) * numpy.inf
-        else:
-            self.params_max = numpy.array(params_max)
-
-    def __call__(self, params):
+    def __call__(self, *params):
         """ Evalualate prior for parameters.
         """
-
-        # check if values are valid and if params are outside of min and max
-        # acceptable values then return -inf
-        params = numpy.array(params)
-        if ((params < self.params_min) | (params > self.params_max)).any():
-            return -numpy.inf
-
-        # evaluate prior for each parameter
-        return sum([prior_distributions[self.params_dist[i]](param) for i,param in enumerate(params)])
-
+        params = dict(zip(self.variable_args, params))
+        return sum([d(**params) for d in self.distributions])

--- a/pycbc/waveform/generator.py
+++ b/pycbc/waveform/generator.py
@@ -80,7 +80,7 @@ class BaseGenerator(object):
     """
     def __init__(self, generator, variable_args=(), **frozen_params):
         self.generator = generator
-        self.variable_args = variable_args
+        self.variable_args = tuple(variable_args)
         self.frozen_params = frozen_params
         # we'll keep a dictionary of the current parameters for fast
         # generation
@@ -197,7 +197,7 @@ class FDomainDetFrameGenerator(object):
         location params are passed to this class's generate function.
     frozen_location_args : dict
         Any location parameters that were included in the frozen_params.
-    variable_args : list
+    variable_args : tuple
         The list of names of arguments that are passed to the generate
         function.
 


### PR DESCRIPTION
This introduces a class for producing uniform priors between some boundaries, and removes boundaries from the PriorEvaluator class. This makes PriorEvaluator agnostic to the details of a particular distribution. For example, in the future we'll probably have priors that have no boundaries (say, for a cyclic function, or for a Gaussian distribution). These can be added as new classes to the module. This patch also moves the no prior (last called flat_prior) function to likelihood.py; it's not really a prior, just a crutch for the likelihood generator. Also add some documentation and sanity checking when the likelihood evaluator is initialized with a prior.
